### PR TITLE
Feature/set user location

### DIFF
--- a/oga/backend/users/urls.py
+++ b/oga/backend/users/urls.py
@@ -6,5 +6,5 @@ urlpatterns = [
     path('questions/', views.questions, name='questions'),
     path('signup/', views.sign_up, name='sign_up'),
     path('signin/', views.sign_in, name='sign_in'),
-    path('location/', views.set_location, name='set_location'),
+    path('location/', views.locations, name='set_location'),
 ]

--- a/oga/backend/users/urls.py
+++ b/oga/backend/users/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('questions/', views.questions, name='questions'),
     path('signup/', views.sign_up, name='sign_up'),
     path('signin/', views.sign_in, name='sign_in'),
+    path('location/', views.set_location, name='set_location'),
 ]

--- a/oga/backend/users/views/__init__.py
+++ b/oga/backend/users/views/__init__.py
@@ -1,3 +1,4 @@
 """view files used for apis"""
 from .views_auth import *
 from .views_question import *
+from .views_location import *

--- a/oga/backend/users/views/views_location.py
+++ b/oga/backend/users/views/views_location.py
@@ -1,0 +1,22 @@
+"""location related views"""
+from django.contrib.auth import get_user
+
+from users.views.decorators import check_request, check_login_required
+from users.models import Location
+
+@check_login_required
+@check_request
+@require_http_methods(["POST"])
+@csrf_exempt
+def locations(request):
+    """on post, store user's location"""
+    req_data = json.loads(request.body.decode())
+    location = req_data['location']
+    location, _ = Location.objects.get_or_create(name=location['name'],
+                                                 latitude=location['latitude'],
+                                                 longitude=location['longitude'])
+    user = get_user(request)
+    user.location = location
+    user.save()
+    response_dict = {'success': True}
+    return JsonResponse(response_dict, status=201)

--- a/oga/backend/users/views/views_location.py
+++ b/oga/backend/users/views/views_location.py
@@ -1,6 +1,10 @@
 """location related views"""
+import json
 from django.contrib.auth import get_user
 
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
 from users.views.decorators import check_request, check_login_required
 from users.models import Location
 
@@ -11,10 +15,10 @@ from users.models import Location
 def locations(request):
     """on post, store user's location"""
     req_data = json.loads(request.body.decode())
-    location = req_data['location']
-    location, _ = Location.objects.get_or_create(name=location['name'],
-                                                 latitude=location['latitude'],
-                                                 longitude=location['longitude'])
+    print(req_data)
+    location, _ = Location.objects.get_or_create(name=req_data['name'],
+                                                 latitude=req_data['latitude'],
+                                                 longitude=req_data['longitude'])
     user = get_user(request)
     user.location = location
     user.save()

--- a/oga/frontend/src/components/LocationListener/LocationListener.js
+++ b/oga/frontend/src/components/LocationListener/LocationListener.js
@@ -24,6 +24,8 @@ import React, { Component } from 'react';
 import haversine from 'haversine'
 import * as actionCreators from '../../store/actions/index';
 import {connect} from 'react-redux';
+import GoogleMapReact from 'google-map-react';
+import API_KEY from '../../const/api_key';
 
 class LocationListener extends Component {
   constructor(props) {
@@ -46,7 +48,7 @@ class LocationListener extends Component {
 
   //returns meter distance between two coordinates
   //returns 0 if prevCoordinates is empty
-  calcDistance = (prevCoordinates, newCoordinates) => {
+  distance = (prevCoordinates, newCoordinates) => {
     //use haversine due to the curviness of the earth
     return haversine(prevCoordinates, newCoordinates, {unit: 'meter'}) || 0;
   };
@@ -58,6 +60,12 @@ class LocationListener extends Component {
         const { latitude, longitude } = position.coords;
         const {previousCoordinates} = this.state;
         const newCoordinates = {
+          // this is left as a dummy string as of now.
+          // to use reverse geocoding of googlemaps, we have to 
+          // display the map(it's google's policy). 
+          // And if we are to use map, defeats the purpose of a light weight
+          // location tracker
+          name: "userlocation",
           latitude,
           longitude
         };
@@ -69,7 +77,7 @@ class LocationListener extends Component {
           return;
         }
 
-        const distance = this.calcDistance(previousCoordinates, newCoordinates);
+        const distance = this.distance(previousCoordinates, newCoordinates);
         if (distance > this.THRESHOLD) {
           this.setState({latitude, longitude, previousCoordinates: newCoordinates});
           this.props.setCurrentCoordinates(newCoordinates);

--- a/oga/frontend/src/store/actions/locationActions.js
+++ b/oga/frontend/src/store/actions/locationActions.js
@@ -22,6 +22,7 @@ export const setTargetLocation = (target) => {
 export const setCurrentCoordinates_ = (coordinates) => {
   return {
     type: actionTypes.SET_CURRENT_COORDINATES,
+    //name: "test",
     latitude: coordinates.latitude,
     longitude: coordinates.longitude,
   }
@@ -29,6 +30,10 @@ export const setCurrentCoordinates_ = (coordinates) => {
 
 export const setCurrentCoordinates = (coordinates) => {
   return (dispatch) => {
-    return dispatch(setCurrentCoordinates_(coordinates));
+    return axios.post('/api/location/', coordinates)
+      .then(res => {
+        dispatch(setCurrentCoordinates_(coordinates));
+        //dispatch(push('/main/questions/'));
+      })
   }
 }


### PR DESCRIPTION
This features enables the user location listener to update user's location in the server.
One thing to note is that we do not store user location's name, although location object has a name field.
This is because to get location's name from coordinates, we have to use google's geocode api. However, google doesn't allow using api by itself; it requires that the map has to be also used. Since we already have a map page, and want to track the user's location in every page, we shall only store the coordinates itself.