### PR TITLE
Feature/check duplicate api

### DIFF
--- a/oga/backend/users/tests/test_auth.py
+++ b/oga/backend/users/tests/test_auth.py
@@ -33,6 +33,16 @@ class AuthTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()['id'], 2)
 
+    def test_signup_existing_user(self):
+        """ try signup with a taken user name"""
+        userinfo = {'username': 'foo', 'password':'bar'}
+        response = self.client.post('/api/signup/', json.dumps(userinfo),
+                                    content_type='application/json')
+        userinfo = {'username': 'foo', 'password':'bar'}
+        response = self.client.post('/api/signup/', json.dumps(userinfo),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 401)
+
     def test_signup_bad_request(self):
         """ try signup with bad request body; should be caught by the decorator """
         userinfo = {'badreqeust': 'foo', 'password':'bar'}

--- a/oga/backend/users/views/views_auth.py
+++ b/oga/backend/users/views/views_auth.py
@@ -18,9 +18,13 @@ def sign_up(request):
     req_data = json.loads(request.body.decode())
     username = req_data['username']
     password = req_data['password']
-    new_user = User.objects.create_user(username=username, password=password)
-    response_dict = {'id': new_user.id}
-    return JsonResponse(response_dict, status=201)
+    if User.objects.filter(username=username).exists():
+        return JsonResponse({"error": "The username already exists"},
+                            status=401)
+    else:
+        new_user = User.objects.create_user(username=username, password=password)
+        response_dict = {'id': new_user.id}
+        return JsonResponse(response_dict, status=201)
 
 @check_request
 @csrf_exempt


### PR DESCRIPTION
When username is already taken during signup, return 401 with error message.