### PR TITLE
show notification based on q/a tag, with extra information

### DIFF
--- a/oga/backend/users/signals.py
+++ b/oga/backend/users/signals.py
@@ -20,24 +20,27 @@ def save_user_profile(sender, instance, **kwargs):
 @receiver(post_save, sender=Question)
 def notify_new_question(sender, instance, created, **kwargs):
     """upon saving a new question, find relevant users and send push
-    notificaiton"""
+    notification"""
     if created:
         qs_l = instance.location_id
         profiles = Profile.objects.all()
+        data = {'text': instance.content, 'location': qs_l.name, 'id': instance.id, 'tag': 'q'}
         for profile in profiles:
             rc_l = profile.location_id
             if (instance.author != profile.user) and profile.location_id:
                 if distance(qs_l, rc_l) <= 0.3:
-                    send_push(profile, {"text": "newquestion!", "tag": "question"})
+                    send_push(profile, data)
 
 @receiver(post_save, sender=Answer)
 def notify_new_answer(sender, instance, created, **kwargs):
     """upon saving a new answer, find owner of question and send push
-    notificaiton"""
+    notification"""
     if created:
-        user = instance.question.author
+        question = instance.question
+        user = question.author
         profile = Profile.objects.get(user=user)
+        location = question.location_id.name
+        data = {'text': instance.content, 'location': location, 'id': instance.id, 'tag': 'a'}
         # user_id = User.objects.get(id=qs_sender_id)
         # profile = Profile.objects.get(user=user_id)
-        send_push(profile, {"text": "newAnswer!", "tag": "answer"})
-        
+        send_push(profile, data)

--- a/oga/frontend/public/sw.js
+++ b/oga/frontend/public/sw.js
@@ -1,20 +1,27 @@
 function receivePushNotification(event) {
-  console.log("HI [Service Worker] Push Received.");
-  console.log(event.data.json().text);
+  const { image, tag, url, title, text, data, id, location } = event.data.json();
+  let options = {}
+  switch(tag) {
+    case 'q':
+      options = {
+        data: 'reply/' + id,
+        body: text +' at\n' + location + '?',
+        tag: tag, //this is needed to hide duplicate notifications
+        actions: [{ action: "Detail", title: "Reply" }]
+      }
+    break;
+    case 'a':
+      options = {
+        data: 'reply/' + id,
+        body: text + ' at\n' + location,
+        tag: tag, //this is needed to hide duplicate notifications
+        actions: [{ action: "Detail", title: "Read" }]
+      }
+    break;
+  }
 
-  const { image, tag, url, title, text, data } = event.data.json();
-
-  const options = {
-    data: url,
-    body: text,
-    //icon: image,
-    //vibrate: [200, 100, 200],
-    tag: "1",
-    //image: image,
-    //badge: "https://spyna.it/icons/favicon.ico",
-    actions: [{ action: "Detail", title: "Look" }]
-  };
-  event.waitUntil(self.registration.showNotification(title, options));
+  console.log(options);
+  event.waitUntil(self.registration.showNotification("Oga", options));
 }
 
 function openPushNotification(event) {


### PR DESCRIPTION
The push notification is now more informative.
When a question has arrived, it will show text like (is it .. at __?) and a reply button, that redirects the user to reply/:id page.
When an answer has arrived, it will show text like (it is .. at __.) and a read button that will take the user to the details page(since this component is not finished, the redirection link is not set yet)