### PR TITLE
Feature/authorization

### DIFF
--- a/oga/backend/oga/settings.py
+++ b/oga/backend/oga/settings.py
@@ -120,3 +120,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+#CSRF COOKIES
+# CSRF_COOKIE_NAME = "XSRF-TOKEN"

--- a/oga/backend/users/urls.py
+++ b/oga/backend/users/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
          views.question_detail, name='question_detail'),
     path('signup/', views.sign_up, name='sign_up'),
     path('signin/', views.sign_in, name='sign_in'),
+    path('is-authed/', views.is_logged_in, name='is_logged_in'),
     path('save-subscription/', views.save_subscription, name='save-subscription'),
     path('location/', views.locations, name='set_location'),
     path('reply/<int:question_id>/', views.create_answer, name='create_answer'),

--- a/oga/backend/users/views/views_auth.py
+++ b/oga/backend/users/views/views_auth.py
@@ -6,8 +6,9 @@ from django.http import JsonResponse
 from django.contrib.auth.models import User
 from django.contrib.auth import login, authenticate
 from django.views.decorators.http import require_http_methods
+from django.views.decorators.csrf import ensure_csrf_cookie
 
-from users.views.decorators import check_request
+from users.views.decorators import check_request, check_login_required
 
 @check_request
 @require_http_methods(["POST"])
@@ -38,3 +39,15 @@ def sign_in(request):
         return JsonResponse(response_dict, status=201)
     else:
         return JsonResponse({}, status=401)
+
+@check_login_required
+@ensure_csrf_cookie
+@require_http_methods(["GET"])
+def is_logged_in(request):
+    """
+    a method that tests if user is logged in or not.
+    if this function passes the @check_login_required,
+    it means the user is logged in so we can
+    just return a OK response
+    """
+    return JsonResponse({}, status=201)

--- a/oga/frontend/src/App.js
+++ b/oga/frontend/src/App.js
@@ -9,9 +9,7 @@ import Map from "./containers/Map/GoogleMap";
 import NewQuestion from "./containers/QuestionList/NewQuestion/NewQuestion.js";
 import PrivateRoute from "./components/PrivateRoute/PrivateRoute.js";
 import NewAnswer from './containers/Answer/NewAnswer';
-import { connect } from "react-redux";
-import * as actionCreators from "./store/actions/index";
-import "./App.css";
+import { connect } from "react-redux"; import * as actionCreators from "./store/actions/index"; import "./App.css";
 
 let swRegistration = null;
 if ('serviceWorker' in navigator && 'PushManager' in window) {
@@ -48,7 +46,7 @@ function App(props) {
             />
             <PrivateRoute
               auth={props.auth}
-              path="/questions/create"
+              path="/ask"
               exact
               component={NewQuestion}
             />
@@ -63,7 +61,7 @@ function App(props) {
               path='/reply/:id'
               exact
               component={NewAnswer} />
-            <Redirect exact from="/" to="main" />
+            <Redirect exact from="/" to="/main" />
             <Route render={() => <h1>Not Found</h1>} />
           </Switch>
         </div>
@@ -81,10 +79,9 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => {
   return {
-    isLoggedIn: () => dispatch(
-      actionCreators.isLoggedIn()
-    )
-  };
+    isLoggedIn: () =>
+      dispatch(actionCreators.isLoggedIn())
+  }
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/oga/frontend/src/App.js
+++ b/oga/frontend/src/App.js
@@ -63,14 +63,13 @@ function App(props) {
               path='/reply/:id'
               exact
               component={NewAnswer} />
-            <Redirect exact from="/" to="login" />
+            <Redirect exact from="/" to="main" />
             <Route render={() => <h1>Not Found</h1>} />
           </Switch>
         </div>
       </ConnectedRouter>
     );
   else {
-    
     console.log("HERE");
     return null;
   }

--- a/oga/frontend/src/App.js
+++ b/oga/frontend/src/App.js
@@ -10,6 +10,7 @@ import NewQuestion from "./containers/QuestionList/NewQuestion/NewQuestion.js";
 import PrivateRoute from "./components/PrivateRoute/PrivateRoute.js";
 import NewAnswer from './containers/Answer/NewAnswer';
 import { connect } from "react-redux";
+import * as actionCreators from "./store/actions/index";
 import "./App.css";
 
 let swRegistration = null;
@@ -17,60 +18,74 @@ if ('serviceWorker' in navigator && 'PushManager' in window) {
   console.log('Service Worker and Push is supported');
 
   navigator.serviceWorker.register('/sw.js')
-  .then(function(swReg) {
-    console.log('Service Worker is registered', swReg);
+    .then(function(swReg) {
+      console.log('Service Worker is registered', swReg);
 
-    swRegistration = swReg;
-  })
-  .catch(function(error) {
-    console.error('Service Worker Error', error);
-  });
+      swRegistration = swReg;
+    })
+    .catch(function(error) {
+      console.error('Service Worker Error', error);
+    });
 } else {
   console.warn('Push messaging is not supported');
 }
 
 function App(props) {
-    let session = false;
-    if (props.auth) session = props.auth;
+  let session = true;
+  props.isLoggedIn(); //sets state's authenticate
+  if (props.auth !== null)
     return (
-        <ConnectedRouter history={props.history}>
-            <div className="App">
-                <Switch>
-                    <Route path="/signup" exact component={Signup} />
-                    <Route path="/login" exact component={Login} />
-                    <PrivateRoute
-                        auth={session}
-                        path="/main"
-                        exact
-                        component={Main}
-                    />
-                    <PrivateRoute
-                        auth={session}
-                        path="/questions/create"
-                        exact
-                        component={NewQuestion}
-                    />
-                    <PrivateRoute
-                        auth={session}
-                        path="/map"
-                        exact
-                        component={Map}
-                    />
-                    <PrivateRoute
-                        auth={session}
-                        path='/reply/:id'
-                        exact
-                        component={NewAnswer} />
-                    <Redirect exact from="/" to="login" />
-                    <Route render={() => <h1>Not Found</h1>} />
-                </Switch>
-            </div>
-        </ConnectedRouter>
+      <ConnectedRouter history={props.history}>
+        <div className="App">
+          <Switch>
+            <Route path="/signup" exact component={Signup} />
+            <Route path="/login" exact component={Login} />
+            <PrivateRoute
+              auth={props.auth}
+              path="/main"
+              exact
+              component={Main}
+            />
+            <PrivateRoute
+              auth={props.auth}
+              path="/questions/create"
+              exact
+              component={NewQuestion}
+            />
+            <PrivateRoute
+              auth={props.auth}
+              path="/map"
+              exact
+              component={Map}
+            />
+            <PrivateRoute
+              auth={props.auth}
+              path='/reply/:id'
+              exact
+              component={NewAnswer} />
+            <Redirect exact from="/" to="login" />
+            <Route render={() => <h1>Not Found</h1>} />
+          </Switch>
+        </div>
+      </ConnectedRouter>
     );
+  else {
+    
+    console.log("HERE");
+    return null;
+  }
 }
 
 const mapStateToProps = state => ({
-    auth: state.auth.authenticated
+  auth: state.auth.authenticated
 });
 
-export default connect(mapStateToProps)(App);
+const mapDispatchToProps = dispatch => {
+  return {
+    isLoggedIn: () => dispatch(
+      actionCreators.isLoggedIn()
+    )
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/oga/frontend/src/App.test.js
+++ b/oga/frontend/src/App.test.js
@@ -1,16 +1,20 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import Login from './containers/Login/Login';
 import { Provider } from 'react-redux';
 import { connectRouter, ConnectedRouter } from 'connected-react-router';
 import { Route, Redirect, Switch } from 'react-router-dom';
+import {connect} from 'react-redux';
 
 import App from './App';
+import Main from './containers/Main/Main';
 import { history } from './store/store';
 import configureMockStore from 'redux-mock-store';
+import * as actionCreators from './store/actions/index';
+import thunk from 'redux-thunk';
 
-const mockStore = configureMockStore();
+const mockStore = configureMockStore([thunk]);
 const store = mockStore({auth: {authenticated: true}, router:history});
+jest.mock("./containers/Main/Main", () => () => <div></div>);
 
 describe('App', () => {
   let app;

--- a/oga/frontend/src/components/PrivateRoute/PrivateRoute.js
+++ b/oga/frontend/src/components/PrivateRoute/PrivateRoute.js
@@ -21,9 +21,12 @@ const PrivateRoute = ({auth: auth, component: Component, ...rest }) => (
       {...rest}
       render={props => {
         if (auth) {
+          console.log(auth);
           return <Component {...props} />;
-        } else
+        } else {
+          console.log(auth);
           return <Redirect to="/login" />;
+        }
       }}/>
 );
 

--- a/oga/frontend/src/containers/Answer/NewAnswer.js
+++ b/oga/frontend/src/containers/Answer/NewAnswer.js
@@ -17,12 +17,14 @@ class NewAnswer extends Component {
     this.state = {
       answer_content: null,
       answered: false,
+      id: this.props.match.params.id,
     };
+    console.log("I am created!!!");
   }
 
 
   componentDidMount() {
-    this.props.onGetQuestion(this.props.match.params.id);
+    this.props.onGetQuestion(this.state.id);
   }
 
   postAnswerHandler = (question_content, answer_content, id) => {
@@ -82,38 +84,6 @@ class NewAnswer extends Component {
         ></AnswerView>
       </React.Fragment>
   }
-
-    // <React.Fragment>
-    //   <div onChange={(event) => this.setState({answer_content: event.target.value})}>
-    //     <input type="radio" value="VERY LONG" name="answer" /> VERY LONG
-    //     <input type="radio" value="LONG" name="answer" /> LONG
-    //     <input type="radio" value="MODERATE" name="answer" /> MIDDLE
-    //     <input type="radio" value="SHORT" name="answer" /> SHORT
-    //     <input type="radio" value="LONG LINE" name="answer" /> LONG LINE
-    //   </div>
-    //   </React.Fragment>
-    //   <React.Fragment>
-    //   <div onChange={(event) => this.setState({answer_content: event.target.value})}>
-    //     <input type="radio" value="MANY" name="answer" /> MANY
-    //     <input type="radio" value="MODERATE" name="answer" /> MODERATE
-    //     <input type="radio" value="SMALL" name="answer" /> SMALL
-    //   </div>
-    //   </React.Fragment>
-    //         <React.Fragment>
-    //         <div onChange={(event) => this.setState({answer_content: event.target.value})}>
-    //           <input type="radio" value="HEAVY" name="answer" /> HEAVY
-    //           <input type="radio" value="MODERATE" name="answer" /> MODERATE
-    //           <input type="radio" value="SMALL" name="answer" /> SMALL
-    //           <input type="radio" value="NO" name="answer" /> NO
-    //         </div>
-    //         </React.Fragment>
-    //               <React.Fragment>
-    //               <div onChange={(event) => this.setState({answer_content: event.target.value})}>
-    //                 <input type="radio" value="NOISY" name="answer" /> NOISY
-    //                 <input type="radio" value="MODERATE" name="answer" /> MODERATE
-    //                 <input type="radio" value="QUIET" name="answer" /> QUIET
-    //               </div>
-    //               </React.Fragment>
 
    return (
       <div className="Answer">

--- a/oga/frontend/src/containers/Main/Main.js
+++ b/oga/frontend/src/containers/Main/Main.js
@@ -4,6 +4,7 @@ import Question from "../../components/Question/Question";
 
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
+import thunk from 'redux-thunk';
 
 import * as actionCreators from "../../store/actions/index";
 
@@ -20,7 +21,7 @@ class QuestionList extends Component {
     };
 
     clickNewQuestionHandler = () => {
-        this.props.history.push("/questions/create");
+        this.props.history.push("/ask");
     };
 
     click;

--- a/oga/frontend/src/index.js
+++ b/oga/frontend/src/index.js
@@ -11,6 +11,7 @@ import store, { history } from './store/store';
 
 axios.defaults.xsrfCookieName = "csrftoken";
 axios.defaults.xsrfHeaderName = "X-CSRFTOKEN";
+//axios.defaults.withCredentials = true
 
 
 ReactDOM.render(

--- a/oga/frontend/src/store/actions/authActions.js
+++ b/oga/frontend/src/store/actions/authActions.js
@@ -46,7 +46,7 @@ export const signIn = user => {
             .post("/api/signin/", user)
             .then(res => {
                 dispatch(signIn_(res));
-                dispatch(push("/questions/create/"));
+                dispatch(push("main"));
             })
             .catch(err => {
                 alert(
@@ -68,11 +68,9 @@ export const isLoggedIn = () => {
     return axios
       .get("/api/is-authed/")
       .then(res => {
-        //return true;
         dispatch(isLoggedIn_(true));
       })
       .catch(err => {
-        //console.log("HERE");
         dispatch(isLoggedIn_(false));
       })
   }

--- a/oga/frontend/src/store/actions/authActions.js
+++ b/oga/frontend/src/store/actions/authActions.js
@@ -35,7 +35,8 @@ export const signUp = user => {
 export const signIn_ = res => {
     return {
         type: actionTypes.AUTHENTICATED,
-        userid: res.data.id
+        //userid: res.data.id,
+        auth: true,
     };
 };
 
@@ -54,3 +55,25 @@ export const signIn = user => {
             });
     };
 };
+
+export const isLoggedIn_ = res => {
+  return {
+    type: actionTypes.AUTHENTICATED,
+    auth: res,
+  }
+}
+
+export const isLoggedIn = () => {
+  return (dispatch) => {
+    return axios
+      .get("/api/is-authed/")
+      .then(res => {
+        //return true;
+        dispatch(isLoggedIn_(true));
+      })
+      .catch(err => {
+        //console.log("HERE");
+        dispatch(isLoggedIn_(false));
+      })
+  }
+}

--- a/oga/frontend/src/store/actions/index.js
+++ b/oga/frontend/src/store/actions/index.js
@@ -4,7 +4,7 @@ import {
     getQuestion,
     getQuestions
 } from "./questionActions.js";
-import { signUp, signIn } from "./authActions.js";
+import { signUp, signIn, isLoggedIn } from "./authActions.js";
 import { createAnswer } from "./answerActions";
 export {
     setTargetLocation,
@@ -14,5 +14,6 @@ export {
     getQuestions,
     signUp,
     signIn,
+    isLoggedIn,
     createAnswer,
 };

--- a/oga/frontend/src/store/reducers/authReducer.js
+++ b/oga/frontend/src/store/reducers/authReducer.js
@@ -1,7 +1,7 @@
 import * as actionTypes from '../actions/actionTypes';
 
 const initialState = {
-  authenticated: false,
+  authenticated: null,
   userid: null,
   //selectedQuestion: null,
   //user_name: null,
@@ -16,9 +16,9 @@ const authReducer = (state = initialState, action) => {
     case actionTypes.AUTHENTICATED:
       const userid = action.userid;
       console.log(action.auth);
-      return { ...state, authenticated: action.auth, userid:userid};
+      return { ...state, authenticated: action.auth};
     case actionTypes.UNAUTHENTICATED:
-      return {...state, authenticated: false, userid:null};
+      return {...state, authenticated: false};
     default:
       break;
   }

--- a/oga/frontend/src/store/reducers/authReducer.js
+++ b/oga/frontend/src/store/reducers/authReducer.js
@@ -15,8 +15,8 @@ const authReducer = (state = initialState, action) => {
       return {...state};
     case actionTypes.AUTHENTICATED:
       const userid = action.userid;
-      console.log(userid);
-      return { ...state, authenticated: true, userid:userid};
+      console.log(action.auth);
+      return { ...state, authenticated: action.auth, userid:userid};
     case actionTypes.UNAUTHENTICATED:
       return {...state, authenticated: false, userid:null};
     default:


### PR DESCRIPTION
Instead of storing user's login state inside server, we ask the server every time.
We might use JWT and local storage, but this seems like a safer option.
(Some links say that JWT SHOULD NOT be used to store auth info in local storage)

All user will be redirected to main. If the user is not authorized, private route will take them to /login.

I have also changed the path name of ```question/create``` to ```ask/```, so that it matches ```reply```