### PR TITLE
split sonar properties to each projects(backend, frontend)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
       script:
       - ./node_modules/.bin/eslint src
       - yarn test --coverage --watchAll=false
-      - cd ../../
       after_success:
       - sonar-scanner
       - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
@@ -40,7 +39,6 @@ matrix:
       - pylint oga
       - coverage run --branch --source='./users' manage.py test && coverage report -m
       - coverage xml
-      - cd ../../
       after_success:
       - sonar-scanner
       - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
       - ./node_modules/.bin/eslint src
       - yarn test --coverage --watchAll=false
       - cd ../../
-      - sonar-scanner
       after_success:
+      - sonar-scanner
       - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
     - language: python
       python: 3.6
@@ -39,7 +39,8 @@ matrix:
       - pylint users
       - pylint oga
       - coverage run --branch --source='./users' manage.py test && coverage report -m
+      - coverage xml
       - cd ../../
-      - sonar-scanner
       after_success:
+      - sonar-scanner
       - coveralls

--- a/oga/backend/sonar-project.properties
+++ b/oga/backend/sonar-project.properties
@@ -6,14 +6,14 @@ sonar.projectVersion=1.0
  
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # This property is optional if sonar.modules is set. 
-sonar.sources=oga/backend,oga/frontend/src
-sonar.tests=oga/backend,oga/frontend/src
+sonar.sources=.
+sonar.tests=.
 
-sonar.exclusions=oga/backend/**/migrations/*
-sonar.test.inclusions=oga/backend/**/tests/*.py,oga/frontend/src/**/*.test.js
+sonar.exclusions=**/migrations/*
+sonar.test.inclusions=**/tests/*.py
 
-sonar.python.coverage.reportPaths=oga/backend/coverage.xml
-sonar.javascript.lcov.reportPaths=oga/frontend/coverage/lcov.info
+sonar.python.coverage.reportPaths=coverage.xml
+#sonar.javascript.lcov.reportPaths=oga/frontend/coverage/lcov.info
  
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/oga/frontend/sonar-project.properties
+++ b/oga/frontend/sonar-project.properties
@@ -10,6 +10,7 @@ sonar.sources=src
 sonar.tests=src
 
 #sonar.exclusions=oga/backend/**/migrations/*
+sonar.exclusions=src/index.js, src/serviceWorker.js, src/store/actions/actionTypes.js, src/setupTests.js
 sonar.test.inclusions=src/**/*.test.js
 
 #sonar.python.coverage.reportPaths=oga/backend/coverage.xml

--- a/oga/frontend/sonar-project.properties
+++ b/oga/frontend/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=swsnu_swpp2019-team15
+
+# this is the name and version displayed in the SonarCloud UI.
+sonar.projectName=swpp2019-team15
+sonar.projectVersion=1.0
+ 
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# This property is optional if sonar.modules is set. 
+sonar.sources=src
+sonar.tests=src
+
+#sonar.exclusions=oga/backend/**/migrations/*
+sonar.test.inclusions=src/**/*.test.js
+
+#sonar.python.coverage.reportPaths=oga/backend/coverage.xml
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+ 
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
By splitting the files, sonar cloud will correctly calculate coverage of each projects.