### PR TITLE
is_logged_in will ensure csrf token

### DIFF
--- a/oga/backend/askat/settings.py
+++ b/oga/backend/askat/settings.py
@@ -42,10 +42,10 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/oga/backend/users/views/views_auth.py
+++ b/oga/backend/users/views/views_auth.py
@@ -43,9 +43,9 @@ def sign_in(request):
         return JsonResponse({}, status=401)
 
 
-@check_login_required
 @ensure_csrf_cookie
 @require_http_methods(["GET"])
+@check_login_required
 def is_logged_in(request):
     """
     a method that tests if user is logged in or not.


### PR DESCRIPTION
1. moved csrfviewmiddleware to the top of the middlewares, so that it is not interfered by other middlewares.

2. is_logged_in() is a view that is checked for every page refresh, and was ideal for ensuring csrf tokens. However, it did not "ensure" tokens, and here is the reason why: due to the order of decorators, login_required is called first. And since new users are not logged in, they get a 401 response, and other decorators are not invoked. By changing the order of decorators, we ensure that csrf tokens are sent before other checks run.