### PR TITLE
Fix/profile test

### DIFF
--- a/oga/frontend/src/containers/Profile/Profile.js
+++ b/oga/frontend/src/containers/Profile/Profile.js
@@ -55,7 +55,7 @@ class Profile extends Component {
                         key={qs.id}
                         id={qs.id}
                         author={qs.author}
-                        publish_date_time={moment(qs.publish_date_time).format(
+                        publish_date_time={moment().format(
                             "MMMM Do YYYY, h:mm:ss a"
                         )}
                         content={qs.content}
@@ -77,7 +77,7 @@ class Profile extends Component {
             );
 
             return (
-                <div style-={{ marginTop: 5, marginBottom: 5 }}>
+                <div style-={{ marginTop: 5, marginBottom: 5 }} key={ans.id}>
                     <Card className="MyAnswer" key={ans.id} align="left">
                         <CardContent
                             onClick={() =>

--- a/oga/frontend/src/containers/Profile/Profile.js
+++ b/oga/frontend/src/containers/Profile/Profile.js
@@ -55,7 +55,7 @@ class Profile extends Component {
                         key={qs.id}
                         id={qs.id}
                         author={qs.author}
-                        publish_date_time={moment().format(
+                        publish_date_time={moment(qs.publish_date_time).format(
                             "MMMM Do YYYY, h:mm:ss a"
                         )}
                         content={qs.content}

--- a/oga/frontend/src/containers/Profile/Profile.test.js
+++ b/oga/frontend/src/containers/Profile/Profile.test.js
@@ -52,7 +52,21 @@ const store = mockStore({
 
 describe("<Profile />", () => {
     let profile;
-
+    const spyProfile = jest
+        .spyOn(authActions, "getProfile")
+        .mockImplementation(() => {
+            return dispatch => {};
+        });
+    const spyProfileQuestions = jest
+        .spyOn(questionActions, "getUserQuestions")
+        .mockImplementation(() => {
+            return dispatch => {};
+        });
+    const spyProfileAnswers = jest
+        .spyOn(answerActions, "getUserAnswers")
+        .mockImplementation(() => {
+            return dispatch => {};
+        });
     beforeEach(() => {
         profile = (
             <Provider store={store}>
@@ -75,21 +89,6 @@ describe("<Profile />", () => {
     });
 
     it("should render profile details without errors", () => {
-        const spyProfileQuestions = jest
-            .spyOn(questionActions, "getUserQuestions")
-            .mockImplementation(() => {
-                return dispatch => {};
-            });
-        const spyProfileAnswers = jest
-            .spyOn(answerActions, "getUserAnswers")
-            .mockImplementation(() => {
-                return dispatch => {};
-            });
-        const spyProfile = jest
-            .spyOn(authActions, "getProfile")
-            .mockImplementation(() => {
-                return dispatch => {};
-            });
         const wrapper = mount(profile);
         expect(spyProfile).toHaveBeenCalled();
         expect(spyProfileQuestions).toHaveBeenCalled();


### PR DESCRIPTION
Since profile needs 3 connections to render properly(profile, qst list, ans list), the three async calls have to be mocked throught the test.
This silences warnings about not waiting for async calls.

Also added key for ans list in profile page.