### PR TITLE
set default center

### DIFF
--- a/oga/frontend/src/containers/Map/GoogleMap.js
+++ b/oga/frontend/src/containers/Map/GoogleMap.js
@@ -152,7 +152,7 @@ class GoogleMap extends Component {
 
   render() {
         const { places, mapApiLoaded, mapInstance, mapApi } = this.state;
-        let center = {lat: 37.4537, lng: 126.9353};
+        let center = {lat: 37.448134, lng: 126.952427};
 
         //FIXME: BUGGY
         console.log(this.props.currentCoordinates);

--- a/oga/frontend/src/containers/Map/GoogleMap.js
+++ b/oga/frontend/src/containers/Map/GoogleMap.js
@@ -152,7 +152,7 @@ class GoogleMap extends Component {
 
   render() {
         const { places, mapApiLoaded, mapInstance, mapApi } = this.state;
-        let center = null;
+        let center = {lat: 37.4537, lng: 126.9353};
 
         //FIXME: BUGGY
         console.log(this.props.currentCoordinates);


### PR DESCRIPTION
Set the default map center to somewhere in SNU.
Users can now ask questions even when they did not share their location.